### PR TITLE
3-4. Componentリファクタリング・マークダウン投稿機能の実装

### DIFF
--- a/src/components/molecules/alertSession.php
+++ b/src/components/molecules/alertSession.php
@@ -10,25 +10,24 @@ class AlertSession {
      * @return void
      */
     public static function render(bool $visibleCloseButton = true): void {
-        $data = PageController::getRedirectData();
-        if (is_null($data) || !isset($data['status']) || !isset($data['message'])) {
+        [$status, $message] = PageController::getRedirectStatus();
+        if ($status === null || $message === null) {
             return;
         }
 
-        $title = match($data['status']) {
+        $title = match($status) {
             'success' => '成功',
             'error' => 'エラー',
             'warning' => '警告',
             default => '',
         };
-
-        $status = match($data['status']) {
+        $status = match($message) {
             'success' => AlertType::SUCCESS,
             'error' => AlertType::ERROR,
             'warning' => AlertType::WARNING,
             default => AlertType::INFO,
         };
 
-        Alert::render($title .': ', $data['message'], $status, $visibleCloseButton);
+        Alert::render($title .': ', $message, $status, $visibleCloseButton);
     }
 }

--- a/src/components/molecules/alertSession.php
+++ b/src/components/molecules/alertSession.php
@@ -21,13 +21,13 @@ class AlertSession {
             'warning' => '警告',
             default => '',
         };
-        $status = match($message) {
+        $type = match($status) {
             'success' => AlertType::SUCCESS,
             'error' => AlertType::ERROR,
             'warning' => AlertType::WARNING,
             default => AlertType::INFO,
         };
 
-        Alert::render($title .': ', $message, $status, $visibleCloseButton);
+        Alert::render($title .': ', $message, $type, $visibleCloseButton);
     }
 }

--- a/src/components/molecules/newsActions.php
+++ b/src/components/molecules/newsActions.php
@@ -24,8 +24,8 @@ class NewsActions {
                         <button  class="bg-red-400 hover:bg-red-500 text-white font-bold py-2 px-4 rounded ">
                             <i class="fa-solid fa-trash"></i> ページを削除
                         </button>
-                        <?php PageController::setCsrfToken()?>
-                        <?php PageController::setDeleteMethod()?>
+                        <?php PageController::setCsrfToken() ?>
+                        <?php PageController::setDeleteMethod() ?>
                     </form>
                 </div>
             </div>

--- a/src/components/molecules/newsActions.php
+++ b/src/components/molecules/newsActions.php
@@ -4,12 +4,12 @@ class NewsActions {
     /**
      * 管理者用操作メニューをレンダリング
      *
-     * @param string $newsId 操作するニュースID
+     * @param string $postId 操作するニュースID
      * @return void
      */
-    public static function render(string $newsId) {
-        $editUrl = './edit.php?id='. $newsId;
-        $deleteUrl = '/actions/news.php?id='. $newsId;
+    public static function render(string $postId) {
+        $editUrl = './edit.php?id='. $postId;
+        $deleteUrl = '/actions/news.php?id='. $postId;
 
         ?>
             <div class="rounded-lg border border-gray-300 m-3 overflow-hidden p-5">

--- a/src/components/molecules/newsCard.php
+++ b/src/components/molecules/newsCard.php
@@ -8,12 +8,14 @@ class NewsCard {
      * ニュースのカードをレンダリング
      *
      * @param PostsDTO $post ニュースのデータ
+     * @param CardSize $mode カードの表示モード
      * @return void
      */
-    public static function render(PostsDTO $post, string $mode): void {
+    public static function render(PostsDTO $post, CardSize $mode): void {
         $newsLink = '/news/index.php?id='. $post->id;
-        $cardSize = $mode === 'card' ? 'w-96' : 'w-full';
+        $cardSize = $mode === CardSize::SMALL ? 'w-96' : 'w-full';
         $thumbnailPath = ImagesRepo::getThumbnailSrcByPostId($post->id);
+        $tags = TagsRepo::getTagsByPostId($post->id);
 
         ?>
             <li class="m-3 <?=$cardSize ?>">
@@ -40,7 +42,7 @@ class NewsCard {
                     </div>
                     <hr class="ml-3 mr-3 mt-1 mb-1">
                     <div class="px-6 pt-4 pb-2">
-                        <?php TagCheckbox::render(false, $post->id) ?>
+                        <?php TagCheckbox::render($tags, false) ?>
                     </div>
                 </div>
             </li>

--- a/src/components/molecules/newsEdit.php
+++ b/src/components/molecules/newsEdit.php
@@ -7,7 +7,7 @@ class NewsEdit {
      * ニュース編集フォームをレンダリング
      *
      * @param ?PostsDTO $post ニュースDTO
-     * @param NewsMode ニュースの表示モード
+     * @param NewsMode $mode ニュースの表示モード
      * @return void
      */
     public static function render(?PostsDTO $post, NewsMode $mode): void {

--- a/src/components/molecules/newsEdit.php
+++ b/src/components/molecules/newsEdit.php
@@ -33,7 +33,7 @@ class NewsEdit {
                     <?php if($isEditMode): ?>
                         <img class="w-full" src="<?=$thumbnailPath?>" alt="news image">
                     <?php else: ?>
-                        <?=SelectImage::render('thumbnail') ?>
+                        <?php SelectImage::render('thumbnail') ?>
                     <?php endif; ?>
                     <article class="p-5">
                         <h2 class="text-4xl text-gray-800 font-bold mt-2 mb-2">

--- a/src/components/molecules/newsEdit.php
+++ b/src/components/molecules/newsEdit.php
@@ -71,7 +71,6 @@ class NewsEdit {
                         event.formData.append(element.name, element.value);
                     });
                 });
-
             </script>
         <?php
     }

--- a/src/components/molecules/newsEdit.php
+++ b/src/components/molecules/newsEdit.php
@@ -61,6 +61,10 @@ class NewsEdit {
                 </div>
             </form>
             <script>
+                const easyMDE = new EasyMDE({
+                    spellChecker: false,
+                    hideIcons: ['guide', 'preview', 'side-by-side'],
+                });
                 document.getElementById('newsForm').addEventListener('formdata', (event) => {
                     document.querySelectorAll('.image-input').forEach((element) => {
                         if (!element?.files?.[0]) return;

--- a/src/components/molecules/newsEdit.php
+++ b/src/components/molecules/newsEdit.php
@@ -7,18 +7,22 @@ class NewsEdit {
      * ニュース編集フォームをレンダリング
      *
      * @param ?PostsDTO $post ニュースDTO
-     * @param string $mode 表示モードか、編集モードか (固定値: MODE_VIEW, MODE_EDIT, MODE_NEW)
+     * @param NewsMode ニュースの表示モード
      * @return void
      */
-    public static function render(?PostsDTO $post, string $mode): void {
-        $newsEditUrl = '/actions/news.php';
-        $isEditMode = false;
-        $thumbnailPath = DEFAULT_THUMBNAIL;
-        if ($mode === MODE_EDIT) {
-            $newsEditUrl .= '?id='. $post->id;
-            $isEditMode = true;
-            $thumbnailPath = ImagesRepo::getThumbnailSrcByPostId($post->id);
-        }
+    public static function render(?PostsDTO $post, NewsMode $mode): void {
+        [$newsEditUrl, $isEditMode, $thumbnailPath] = match($mode) {
+            NewsMode::EDIT => [
+                '/actions/news.php?id='. $post->id,
+                true,
+                ImagesRepo::getThumbnailSrcByPostId($post->id)
+            ],
+            default => [
+                '/actions/news.php',
+                false,
+                DEFAULT_THUMBNAIL
+            ]
+        };
 
         $title = $post->title ?? '';
         $body = $post->body ?? '';

--- a/src/components/molecules/newsView.php
+++ b/src/components/molecules/newsView.php
@@ -29,11 +29,22 @@ class NewsView {
                                 </p>
                             <?php endif; ?>
                         </div>
-                        <p class="text-gray-700 mt-8">
-                            <?=replaceBrTagByNewLineCharacter(convertSpecialCharsToHtmlEntities($post->body)) ?>
+                        <iframe class="w-full" id="message" srcdoc="" scrolling="no" sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"></iframe>
+                        <p id="message-raw" class="hidden">
+<?=convertSpecialCharsToHtmlEntities($post->body) ?>
                         </p>
                     </section>
                 </article>
+                <script>
+                    const rawMd = document.getElementById('message-raw').innerText
+                    const md = DOMPurify.sanitize(marked.parse(rawMd));
+
+                    const iframeElement = document.getElementById('message');
+                    iframeElement.srcdoc = md.replaceAll('<a', '<a target="_self" ');
+                    iframeElement.addEventListener('load', () => {
+                        iframeElement.style.height = (iframeElement.contentWindow.document.body.scrollHeight + 50) + 'px';
+                    });
+                </script>
             </main>
         <?php
     }

--- a/src/components/molecules/tagCheckbox.php
+++ b/src/components/molecules/tagCheckbox.php
@@ -3,17 +3,7 @@
 require_once __DIR__ .'/../atoms/badge.php';
 
 class TagCheckbox {
-    public static function render(bool $enable, ?string $postId = null): void {
-        $db = PDOFactory::getNewPDOInstance();
-        $tagsDao = new TagsDAO($db);
-
-        $tags = [];
-        if (is_null($postId)) {
-            $tags = $tagsDao->getTags();
-        } else {
-            $tags = $tagsDao->getTagsByPostId($postId);
-        }
-
+    public static function render(array $tags, bool $enable): void {
         ?>
             <?php if($enable): ?>
                 <?php foreach($tags as $tag): ?>

--- a/src/components/molecules/userInfo.php
+++ b/src/components/molecules/userInfo.php
@@ -8,6 +8,7 @@ class UserInfo {
      */
     public static function render(UsersDTO $user, string $title, int $postsCount, bool $visibleSettingButton): void {
         $userUrl = '/user/index.php?id='. $user->id;
+
         ?>
             <section class="bg-gray-100 border border-gray-300 rounded-lg p-5">
                 <h3 class="text-xl text-gray-800 font-bold border-b border-gray-400">

--- a/src/components/organisms/newsDetail.php
+++ b/src/components/organisms/newsDetail.php
@@ -18,7 +18,7 @@ class NewsDetail {
      * @return void
      */
     public static function render(UsersDTO $user, ?PostsDTO $post, NewsMode $mode): void {
-        $editorMode = $mode === NewsMode::EDIT || $mode === NewsMode::CREATE;
+        $editorMode = in_array($mode, [NewsMode::EDIT, NewsMode::CREATE], true);
 
         $breadcrumbProps = match($mode) {
             NewsMode::EDIT => [

--- a/src/components/organisms/newsDetail.php
+++ b/src/components/organisms/newsDetail.php
@@ -14,30 +14,25 @@ class NewsDetail {
      *
      * @param UsersDTO $user ユーザーDTO
      * @param ?PostsDTO $post 投稿DTO
-     * @param string $mode 表示モードか、編集モードか (固定値: MODE_VIEW, MODE_EDIT, MODE_CREATE)
+     * @param NewsMode $mode ニュース表示モード
      * @return void
      */
-    public static function render(UsersDTO $user, ?PostsDTO $post, string $mode): void {
-        $editorMode = in_array($mode, [MODE_EDIT, MODE_CREATE]);
+    public static function render(UsersDTO $user, ?PostsDTO $post, NewsMode $mode): void {
+        $editorMode = $mode === NewsMode::EDIT || $mode === NewsMode::CREATE;
 
-        $breadcrumbProps = [];
-        if ($mode === MODE_EDIT) {
-            $breadcrumbProps = [
-                ['name' => 'ニュース - '. $post->title, 'link' => 'index.php?id='. $post->id],
+        $breadcrumbProps = match($mode) {
+            NewsMode::EDIT => [
+                ['name' => 'ニュース - '. $post->title, 'link' => '/news/index.php?id='. $post->id],
                 ['name' => 'ページを編集', 'link' => $_SERVER['REQUEST_URI']],
-            ];
-        }
-        elseif ($mode === MODE_CREATE) {
-            $breadcrumbProps = [
+            ],
+            NewsMode::CREATE => [
                 ['name' => 'ユーザー - @'. $user->username, 'link' => '/user/index.php?id='. $user->id],
                 ['name' => 'ニュースを作成', 'link' => $_SERVER['REQUEST_URI']],
-            ];
-        }
-        elseif ($mode === MODE_VIEW) {
-            $breadcrumbProps = [
+            ],
+            default => [
                 ['name' => 'ニュース - '. $post->title, 'link' => $_SERVER['REQUEST_URI']]
-            ];
-        }
+            ]
+        };
 
         ?>
             <div class="w-full lg:w-3/6 ">

--- a/src/components/organisms/newsInfo.php
+++ b/src/components/organisms/newsInfo.php
@@ -12,10 +12,16 @@ class NewsInfo {
      * @param UsersDTO $user ユーザーDTO
      * @param PostsDTO $user ニュース投稿DTO
      * @param integer $postsCount 投稿数
-     * @param string $mode 表示モードか、編集モードか (固定値: MODE_VIEW, MODE_EDIT, MODE_CREATE)
+     * @param NewsMode $mode ニュース表示モード
      * @return void
      */
-    public static function render(UsersDTO $user, ?PostsDTO $post, int $postsCount, string $mode): void {
+    public static function render(UsersDTO $user, ?PostsDTO $post, int $postsCount, NewsMode $mode): void {
+        $isCreateMode = $mode === NewsMode::CREATE;
+        $tags = match($mode) {
+            NewsMode::CREATE => TagsRepo::getTags(),
+            default => TagsRepo::getTagsByPostId($post->id)
+        };
+
         ?>
             <aside class="w-full lg:w-80 m-3">
                 <?php UserInfo::render(user: $user, postsCount: $postsCount, title: '投稿者', visibleSettingButton: false) ?>
@@ -24,7 +30,7 @@ class NewsInfo {
                         <i class="fa-solid fa-tags"></i> タグ
                     </h3>
                     <div class="mt-3 flex flex-wrap">
-                        <?php TagCheckbox::render($mode === MODE_CREATE, $post->id ?? null) ?>
+                        <?php TagCheckbox::render($tags, $isCreateMode) ?>
                     </div>
                 </section>
                 <section class="border border-gray-300 rounded-lg p-5 mt-3">
@@ -32,7 +38,7 @@ class NewsInfo {
                         <i class="fa-solid fa-images"></i> 画像一覧
                     </h3>
                     <div class="mt-5">
-                        <?php if ($mode === MODE_CREATE): ?>
+                        <?php if ($isCreateMode): ?>
                             <?php for($i = 0; $i < MAX_IMAGE_COUNT; $i++): ?>
                                 <div class="mt-2 rounded-md overflow-hidden">
                                     <form id="imageForm">

--- a/src/components/organisms/newsInfo.php
+++ b/src/components/organisms/newsInfo.php
@@ -15,8 +15,9 @@ class NewsInfo {
      * @param NewsMode $mode ニュース表示モード
      * @return void
      */
-    public static function render(UsersDTO $user, ?PostsDTO $post, int $postsCount, NewsMode $mode): void {
+    public static function render(UsersDTO $user, ?PostsDTO $post, NewsMode $mode): void {
         $isCreateMode = $mode === NewsMode::CREATE;
+        $postsCount = PostsRepo::getPostsCountByUserId($user->id);
         $tags = match($mode) {
             NewsMode::CREATE => TagsRepo::getTags(),
             default => TagsRepo::getTagsByPostId($post->id)

--- a/src/components/organisms/newsList.php
+++ b/src/components/organisms/newsList.php
@@ -18,7 +18,7 @@ class NewsList {
                 <ul class="flex justify-center flex-wrap">
                     <?php if (count($posts) > 0): ?>
                         <?php foreach ($posts as $post): ?>
-                            <?php NewsCard::render($post, 'card') ?>
+                            <?php NewsCard::render($post, CardSize::SMALL) ?>
                         <?php endforeach; ?>
                     <?php else: ?>
                         <div class="flex justify-center items-center my-3">

--- a/src/components/organisms/userDetail.php
+++ b/src/components/organisms/userDetail.php
@@ -11,9 +11,7 @@ class UserDetail {
      */
     public static function render(UsersDTO $user) {
         // 投稿データ取得
-        $db = PDOFactory::getNewPDOInstance();
-        $postsDao = new PostsDAO($db);
-        $postsCount = $postsDao->getPostsCountByUserId($user->id);
+        $postsCount = PostsRepo::getPostsCountByUserId($user->id);
 
         ?>
             <aside class="w-full lg:w-80 m-3">

--- a/src/components/organisms/userDetail.php
+++ b/src/components/organisms/userDetail.php
@@ -10,7 +10,6 @@ class UserDetail {
      * @return void
      */
     public static function render(UsersDTO $user) {
-        // 投稿データ取得
         $postsCount = PostsRepo::getPostsCountByUserId($user->id);
 
         ?>

--- a/src/components/organisms/userPosts.php
+++ b/src/components/organisms/userPosts.php
@@ -10,8 +10,8 @@ class UserPosts {
      * @param string $username ユーザー名
      * @return void
      */
-    public static function render(string $username): void {
-        $posts = PostsRepo::getPostsByUserId($_GET['id']);
+    public static function render(string $userId, string $username): void {
+        $posts = PostsRepo::getPostsByUserId($userId);
         $breadcrumbProps = [
             ['name' => 'ユーザー - @'. $username, 'link' => $_SERVER['REQUEST_URI']]
         ];

--- a/src/components/organisms/userPosts.php
+++ b/src/components/organisms/userPosts.php
@@ -11,11 +11,7 @@ class UserPosts {
      * @return void
      */
     public static function render(string $username): void {
-        $db = PDOFactory::getNewPDOInstance();
-
-        $postsDao = new PostsDAO($db);
-        $posts = $postsDao->getPostsByUserId($_GET['id']);
-
+        $posts = PostsRepo::getPostsByUserId($_GET['id']);
         $breadcrumbProps = [
             ['name' => 'ユーザー - @'. $username, 'link' => $_SERVER['REQUEST_URI']]
         ];
@@ -27,7 +23,7 @@ class UserPosts {
                 </div>
                 <ul class="flex justify-center flex-wrap">
                     <?php foreach ($posts as $post): ?>
-                        <?=NewsCard::render($post, 'full') ?>
+                        <?=NewsCard::render($post, CardSize::WIDE) ?>
                     <?php endforeach; ?>
                 </ul>
             </div>

--- a/src/components/pages/home.php
+++ b/src/components/pages/home.php
@@ -17,10 +17,7 @@ class Home {
      * @return void
      */
     public static function render(): void {
-        $db = PDOFactory::getNewPDOInstance();
-        $postsDao = new PostsDAO($db);
-
-        $posts = $postsDao->getPosts();
+        $posts = PostsRepo::getPosts();
 
         ?>
             <?php Head::render('Flash News')?>

--- a/src/components/pages/news.php
+++ b/src/components/pages/news.php
@@ -14,41 +14,31 @@ class News {
     /**
      * ニュース詳細ページをレンダリング
      * 
-     * @param string $mode 表示モードか、編集モードか (固定値: MODE_VIEW, MODE_EDIT, MODE_CREATE)
+     * @param NewsMode $mode ニュースの表示モード
      * @return void 
      */
-    public static function render(string $mode): void {
-        if ($mode !== MODE_CREATE && !isset($_GET['id'])) {
-            PageController::redirectWithStatus('/error.php', 'error', 'ニュースIDが指定されていません。');
-        }
-
-        $db = PDOFactory::getNewPDOInstance();
-
-        $usersDao = new UsersDAO($db);
-        $user = $usersDao->getUserByEmail('test@test.com');
-
-        $postsDao = new PostsDAO($db);
-        $postsCount = $postsDao->getPostsCountByUserId($user->id);
-
+    public static function render(NewsMode $mode): void {
         $title = '新規作成';
         $post = null;
-        if (in_array($mode, [MODE_VIEW, MODE_EDIT])) {
-            // 編集・閲覧モード
-            // 投稿データ取得
-            $post = $postsDao->getPostById($_GET['id']);
+        if (in_array($mode, [NewsMode::EDIT, NewsMode::VIEW], true)) {
+            if (!isset($_GET['id'])) {
+                PageController::redirectWithStatus('/error.php', 'error', 'ニュースIDは数値で指定してください。');
+            }
+            $post = PostsRepo::getPostById($_GET['id']);
             if (is_null($post)) {
                 PageController::redirectWithStatus('/error.php', 'error', '投稿が見つかりませんでした。');
             }
             $title = $post->title;
         }
-    
+        $user = UsersRepo::getUserByEmail('test@test.com');
+
         ?>
             <?php Head::render('Flash News - '. $title) ?>
                 <body>
                     <?php Header::render() ?>
                     <section class="flex justify-center flex-wrap items-start">
                         <?php NewsDetail::render($user, $post, $mode) ?>
-                        <?php NewsInfo::render($user, $post, $postsCount, $mode) ?>
+                        <?php NewsInfo::render($user, $post, $mode) ?>
                     </section>
                     <?php Footer::render() ?>
                 </body>

--- a/src/components/pages/user.php
+++ b/src/components/pages/user.php
@@ -17,16 +17,12 @@ class User {
      * @return void
      */
     public static function render(): void {
-        $db = PDOFactory::getNewPDOInstance();
-
         if (!isset($_GET['id'])) {
             PageController::redirectWithStatus('/error.php', 'error', 'ユーザーIDが指定されていません。');
         }
 
         // ユーザーデータ取得
-        $usersDao = new UsersDAO($db);
-        $user = $usersDao->getUserById($_GET['id']);
-
+        $user = UsersRepo::getUserById($_GET['id']);
         if (!isset($user)) {
             PageController::redirectWithStatus('/error.php', 'error', 'ユーザーが見つかりませんでした。');
         }

--- a/src/components/pages/user.php
+++ b/src/components/pages/user.php
@@ -36,7 +36,7 @@ class User {
                 <body>
                     <?=Header::render() ?>
                     <section class="flex justify-center flex-wrap-reverse items-end">
-                        <?=UserPosts::render($user->username) ?>
+                        <?=UserPosts::render($user->id, $user->username) ?>
                         <?=userDetail::render($user) ?>
                     </section>
                     <?=Footer::render() ?>

--- a/src/components/templates/head.php
+++ b/src/components/templates/head.php
@@ -17,6 +17,10 @@ class Head {
                     <meta name="viewport" content="width=device-width, initial-scale=1.0">
                     <script src="https://cdn.tailwindcss.com"></script>
                     <link rel="stylesheet" href="/css/common.css">
+                    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.3/purify.min.js" integrity="sha512-TBmnYz6kBCpcGbD55K7f4LZ+ykn3owqujFnUiTSHEto6hMA7aV4W7VDPvlqDjQImvZMKxoR0dNY5inyhxfZbmA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+                    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+                    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+                    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
                     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js" integrity="sha512-fD9DI5bZwQxOi7MhYWnnNPlvXdp/2Pj3XSTRrFs5FQa4mizyGLnJcN6tuvUS6LbmgN1ut+XGSABKvjN0H6Aoow==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
                 </head>

--- a/src/components/templates/header.php
+++ b/src/components/templates/header.php
@@ -7,10 +7,7 @@ class Header {
      * @return void
      */
     public static function render(): void {
-        $db = PDOFactory::getNewPDOInstance();
-        $usersDao = new UsersDAO($db);
-        
-        $user = $usersDao->getUserByEmail('test@test.com');
+        $user = UsersRepo::getUserByEmail('test@test.com');
         $userUrl = '/user/index.php?id='. $user->id;
 
         ?>

--- a/src/functions/const.php
+++ b/src/functions/const.php
@@ -5,10 +5,16 @@ const METHOD_NAME = '_method';
 
 const REDIRECT_INDEX = 'redirect_data';
 
-const MODE_EDIT = 'edit';
-const MODE_VIEW = 'view';
-const MODE_CREATE = 'create';
-
 const MAX_IMAGE_COUNT = 4;
-
 const DEFAULT_THUMBNAIL = '/img/news.jpg';
+
+enum NewsMode {
+    case EDIT;
+    case VIEW;
+    case CREATE;
+}
+
+enum CardSize {
+    case SMALL;
+    case WIDE;
+}

--- a/src/functions/pageController/pageController.php
+++ b/src/functions/pageController/pageController.php
@@ -29,9 +29,9 @@ class PageController {
     }
 
     /**
-     * セッションデータがあるかどうか
+     * リダイレクトデータが存在するか
      *
-     * @return boolean
+     * @return boolean リダイレクトデータが存在するか
      */
     public static function hasRedirectData(): bool {
         return isset($_SESSION[REDIRECT_INDEX]);
@@ -40,12 +40,32 @@ class PageController {
     /**
      * リダイレクトデータを取得
      *
-     * @return array リダイレクト時のセッションデータ
+     * @return array|null リダイレクト時のセッションデータ
      */
     public static function getRedirectData(): ?array {
-        $data = $_SESSION[REDIRECT_INDEX] ?? null;
+        if (!isset($_SESSION[REDIRECT_INDEX])) {
+            return null;
+        }
+
+        $data = $_SESSION[REDIRECT_INDEX];
         unset($_SESSION[REDIRECT_INDEX]);
         return $data;
+    }
+
+    /**
+     * リダイレクトステータスを取得
+     *
+     * @return array リダイレクト時のステータス
+     */
+    public static function getRedirectStatus(): array {
+        if (!isset($_SESSION[REDIRECT_INDEX]['status']) || !isset($_SESSION[REDIRECT_INDEX]['message'])) {
+            return [null, null];
+        }
+
+        $data = $_SESSION[REDIRECT_INDEX];
+        unset($_SESSION[REDIRECT_INDEX]);
+
+        return [$data['status'], $data['message']];
     }
 
     /**

--- a/src/functions/pageController/pageController.php
+++ b/src/functions/pageController/pageController.php
@@ -55,7 +55,7 @@ class PageController {
     /**
      * リダイレクトステータスを取得
      *
-     * @return array リダイレクト時のステータス
+     * @return array {status: string, message: string} リダイレクト時のステータス
      */
     public static function getRedirectStatus(): array {
         if (!isset($_SESSION[REDIRECT_INDEX]['status']) || !isset($_SESSION[REDIRECT_INDEX]['message'])) {

--- a/src/models/PDOFactory.php
+++ b/src/models/PDOFactory.php
@@ -12,14 +12,14 @@ class PDOFactory {
      * PDOインスタンスを取得
      *
      * @param boolean $forceNew 強制的にPDOを再生成するかどうか
-     * @return PDO PDOインスタンス
+     * @return ?PDO PDOインスタンス
      */
-    public static function getPDOInstance(bool $forceNew = false): PDO
+    public static function getPDOInstance(bool $forceNew = false): ?PDO
     {
         if ($forceNew) {
             static::$pdo = static::getNewPDOInstance();
         }
-        return static::$pdo;
+        return static::$pdo ?? null;
     }
 
     /**

--- a/src/models/autoload.php
+++ b/src/models/autoload.php
@@ -13,3 +13,4 @@ require_once __DIR__ . '/dto/images.php';
 require_once __DIR__ . '/dto/tags.php';
 
 require_once __DIR__ . '/repo/images.php';
+require_once __DIR__ . '/repo/tags.php';

--- a/src/models/autoload.php
+++ b/src/models/autoload.php
@@ -12,5 +12,7 @@ require_once __DIR__ . '/dto/users.php';
 require_once __DIR__ . '/dto/images.php';
 require_once __DIR__ . '/dto/tags.php';
 
+require_once __DIR__ . '/repo/posts.php';
+require_once __DIR__ . '/repo/users.php';
 require_once __DIR__ . '/repo/images.php';
 require_once __DIR__ . '/repo/tags.php';

--- a/src/models/dao/images.php
+++ b/src/models/dao/images.php
@@ -74,8 +74,8 @@ class ImagesDAO {
     /**
      * 投稿IDを元に画像を取得
      *
-     * @param string $postId
-     * @return array
+     * @param string $postId 投稿ID
+     * @return ?ImagesDTO 画像DTO
      */
     public function getThumbnailByPostId(string $postId): ?ImagesDTO {
         $imagesTable = $this::IMAGES_TABLE;

--- a/src/models/dao/images.php
+++ b/src/models/dao/images.php
@@ -18,7 +18,14 @@ class ImagesDAO {
      * @return boolean トランザクションが成功したかどうか
      */
     public function createImage(string $imageId, string $postId, bool $thumbnailFlag, string $filePath): string {
-        $sql = 'INSERT INTO '. $this::IMAGES_TABLE .' (id, post_id, thumbnail_flag, file_path) VALUES (:id, :post_id, :thumbnail_flag, :file_path)';
+        $imagesTable= $this::IMAGES_TABLE;
+        $sql = <<<SQL
+            INSERT INTO {$imagesTable} 
+                (id, post_id, thumbnail_flag, file_path) 
+            VALUES 
+                (:id, :post_id, :thumbnail_flag, :file_path)
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $imageId, PDO::PARAM_STR);
         $stmt->bindValue(':post_id', $postId, PDO::PARAM_STR);
@@ -36,7 +43,14 @@ class ImagesDAO {
      * @return array
      */
     public function getImagesByPostId(string $postId): array {
-        $sql = 'SELECT * FROM '. $this::IMAGES_TABLE .' WHERE post_id = :post_id AND thumbnail_flag = FALSE';
+        $imagesTable = $this::IMAGES_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM 
+                {$imagesTable}
+            WHERE 
+                post_id = :post_id AND thumbnail_flag = FALSE
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':post_id', $postId, PDO::PARAM_STR);
 
@@ -64,7 +78,13 @@ class ImagesDAO {
      * @return array
      */
     public function getThumbnailByPostId(string $postId): ?ImagesDTO {
-        $sql = 'SELECT * FROM '. $this::IMAGES_TABLE .' WHERE post_id = :post_id AND thumbnail_flag = TRUE';
+        $imagesTable = $this::IMAGES_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM 
+                {$imagesTable}
+            WHERE
+                post_id = :post_id AND thumbnail_flag = TRUE
+        SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':post_id', $postId, PDO::PARAM_STR);
 

--- a/src/models/dao/posts.php
+++ b/src/models/dao/posts.php
@@ -10,27 +10,6 @@ class PostsDAO {
     }
 
     /**
-     * ニュースを作成
-     *
-     * @param string $userId ユーザーID
-     * @param string $title タイトル
-     * @param string $body 内容
-     * @return boolean トランザクションが成功したかどうか
-     */
-    public function createPost(string $userId, string $title, string $body): string {
-        $newsId = 'post_' . uniqid(mt_rand());
-        $sql = 'INSERT INTO '. $this::POSTS_TABLE .' (id, user_id, title, body) VALUES (:id, :user_id, :title, :body)';
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindValue(':id', $newsId, PDO::PARAM_STR);
-        $stmt->bindValue(':user_id', $userId, PDO::PARAM_STR);
-        $stmt->bindValue(':title', $title, PDO::PARAM_STR);
-        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
-
-        $stmt->execute();
-        return $newsId;
-    }
-
-    /**
      * 渡されたStatementを元に、複数のニュースを取得・PostsDTOに格納
      *
      * @param PDOStatement $stmt PostsテーブルのPDOStatement
@@ -54,12 +33,47 @@ class PostsDAO {
     }
 
     /**
+     * ニュースを作成
+     *
+     * @param string $userId ユーザーID
+     * @param string $title タイトル
+     * @param string $body 内容
+     * @return boolean トランザクションが成功したかどうか
+     */
+    public function createPost(string $userId, string $title, string $body): string {
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            INSERT INTO {$postsTable} 
+                (id, user_id, title, body)
+            VALUES 
+                (:id, :user_id, :title, :body)
+        SQL;
+
+        $newsId = 'post_' . uniqid(mt_rand());
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':id', $newsId, PDO::PARAM_STR);
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
+
+        $stmt->execute();
+        return $newsId;
+    }
+
+    /**
      * 全てのニュースを取得
      *
      * @return array PostsDTOの配列
      */
     public function getPosts(): array {
-        $sql = 'SELECT * FROM '. $this::POSTS_TABLE .' WHERE deleted_at IS NULL';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM 
+                {$postsTable} 
+            WHERE 
+                deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->query($sql);
         if (!$stmt->execute()) {
             return [];
@@ -75,7 +89,14 @@ class PostsDAO {
      * @return array PostsDTOの配列
      */
     public function getPostsByUserId(string $userId): array {
-        $sql = 'SELECT * FROM '. $this::POSTS_TABLE .' WHERE user_id = :user_id AND deleted_at IS NULL';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM
+                {$postsTable}
+            WHERE
+                user_id = :user_id AND deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':user_id', $userId, PDO::PARAM_STR);
         if (!$stmt->execute()) {
@@ -92,7 +113,14 @@ class PostsDAO {
      * @return integer ニュースの件数
      */
     public function getPostsCountByUserId(string $userId): int {
-        $sql = 'SELECT COUNT(*) as count FROM '. $this::POSTS_TABLE .' WHERE user_id = :user_id AND deleted_at IS NULL';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            SELECT 
+                COUNT(*) as count FROM {$postsTable}
+            WHERE 
+                user_id = :user_id AND deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':user_id', $userId, PDO::PARAM_STR);
         if (!$stmt->execute()) {
@@ -110,7 +138,14 @@ class PostsDAO {
      * @return PostsDTO|null ニュースのDTO
      */
     public function getPostById(string $id): ?PostsDTO {
-        $sql = 'SELECT * FROM '. $this::POSTS_TABLE .' WHERE id = :id AND deleted_at IS NULL';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM 
+                {$postsTable}
+            WHERE
+                id = :id AND deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $id, PDO::PARAM_STR);
 
@@ -133,8 +168,24 @@ class PostsDAO {
         );
     }
 
+    /**
+     * ニュースIDを元にニュースを更新
+     *
+     * @param string $id ニュースID
+     * @param string $title タイトル
+     * @param string $body 内容
+     * @return boolean 更新に成功したかどうか
+     */
     public function putPostById(string $id, string $title, string $body): bool {
-        $sql = 'UPDATE '. $this::POSTS_TABLE .' SET title = :title, body = :body, updated_at = :updated_at WHERE id = :id';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            UPDATE {$postsTable} 
+            SET 
+                title = :title, body = :body, updated_at = :updated_at 
+            WHERE
+                id = :id
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $id, PDO::PARAM_STR);
         $stmt->bindValue(':title', $title, PDO::PARAM_STR);
@@ -144,8 +195,21 @@ class PostsDAO {
         return $stmt->execute();
     }
 
+    /**
+     * ニュースIDを元にニュースを削除
+     *
+     * @param string $id ニュースID
+     * @return boolean 削除に成功したかどうか
+     */
     public function deletePostById(string $id): bool {
-        $sql = 'UPDATE '. $this::POSTS_TABLE .' SET deleted_at = :deleted_at WHERE id = :id';
+        $postsTable = $this::POSTS_TABLE;
+        $sql = <<<SQL
+            UPDATE {$postsTable}
+            SET
+                deleted_at = :deleted_at
+            WHERE id = :id
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':deleted_at', (new DateTime())->format(DateTime::ATOM), PDO::PARAM_STR);
         $stmt->bindValue(':id', $id, PDO::PARAM_STR);

--- a/src/models/dao/posts.php
+++ b/src/models/dao/posts.php
@@ -49,15 +49,15 @@ class PostsDAO {
                 (:id, :user_id, :title, :body)
         SQL;
 
-        $newsId = 'post_' . uniqid(mt_rand());
+        $postId = 'post_' . uniqid(mt_rand());
         $stmt = $this->db->prepare($sql);
-        $stmt->bindValue(':id', $newsId, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $postId, PDO::PARAM_STR);
         $stmt->bindValue(':user_id', $userId, PDO::PARAM_STR);
         $stmt->bindValue(':title', $title, PDO::PARAM_STR);
         $stmt->bindValue(':body', $body, PDO::PARAM_STR);
 
         $stmt->execute();
-        return $newsId;
+        return $postId;
     }
 
     /**

--- a/src/models/dao/tags.php
+++ b/src/models/dao/tags.php
@@ -79,8 +79,10 @@ class TagsDAO {
         $relationTable = $this::RELATION_TAGS_POSTS_TABLE;
 
         $sql = <<<SQL
-            INSERT INTO {$relationTable} (tag_id, post_id)
-                VALUES (:tag_id, :post_id)
+            INSERT INTO {$relationTable} 
+                (tag_id, post_id)
+            VALUES 
+                (:tag_id, :post_id)
         SQL;
     
         $stmt = $this->db->prepare($sql);

--- a/src/models/dao/users.php
+++ b/src/models/dao/users.php
@@ -19,7 +19,14 @@ class UsersDAO {
      * @return boolean トランザクションが成功したかどうか
      */
     public function createUser(string $username, string $email, string $password, string $profileImagePath = ''): bool {
-        $sql = 'INSERT INTO '. $this::USERS_TABLE .' (id, username, email, password, profile_img_path) VALUES (:id, :username, :email, :password, :profile_img_path)';
+        $usersTable = $this::USERS_TABLE;
+        $sql = <<<SQL
+            INSERT INTO {$usersTable}
+                (id, username, email, password, profile_img_path)
+            VALUES
+                (:id, :username, :email, :password, :profile_img_path)
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', 'user_'.uniqid(mt_rand()), PDO::PARAM_STR);
         $stmt->bindValue(':username', $username, PDO::PARAM_STR);
@@ -37,7 +44,14 @@ class UsersDAO {
      * @return UsersDTO|null ユーザーが存在しない場合はnull
      */
     public function getUserByEmail(string $email): ?UsersDTO {
-        $sql = 'SELECT * FROM '. $this::USERS_TABLE .' WHERE email = :email AND deleted_at IS NULL';
+        $usersTable = $this::USERS_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM
+                {$usersTable} 
+            WHERE
+                email = :email AND deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':email', $email, PDO::PARAM_STR);
         $stmt->execute();
@@ -65,7 +79,14 @@ class UsersDAO {
      * @return UsersDTO|null ユーザーが存在しない場合はnull
      */
     public function getUserById(string $id): ?UsersDTO {
-        $sql = 'SELECT * FROM '. $this::USERS_TABLE .' WHERE id = :id AND deleted_at IS NULL';
+        $usersTable = $this::USERS_TABLE;
+        $sql = <<<SQL
+            SELECT * FROM 
+                {$usersTable}
+            WHERE
+                id = :id AND deleted_at IS NULL
+        SQL;
+
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $id, PDO::PARAM_STR);
         $stmt->execute();

--- a/src/models/repo/images.php
+++ b/src/models/repo/images.php
@@ -5,12 +5,13 @@ class ImagesRepo {
      * サムネイルの画像パスを取得
      *
      * @param string $postId 投稿ID
+     * @param ?PDO $pdo PDOインスタンス
      * @return string 画像パス
      */
-    public static function getThumbnailSrcByPostId(string $postId): string {
-        $db = PDOFactory::getPDOInstance();
+    public static function getThumbnailSrcByPostId(string $postId, PDO $pdo = null): string {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
 
-        $imagesDao = new ImagesDAO($db);
+        $imagesDao = new ImagesDAO($pdo);
         $imagesDto = $imagesDao->getThumbnailByPostId($postId);
 
         if (is_null($imagesDto)) {
@@ -24,12 +25,13 @@ class ImagesRepo {
      * 投稿IDを元に画像パスリストを取得
      *
      * @param string $postId 投稿ID
+     * @param ?PDO $pdo PDOインスタンス
      * @return array 画像パスリスト
      */
-    public static function getImagesSrcByPostId(string $postId): array {
-        $db = PDOFactory::getPDOInstance();
+    public static function getImagesSrcByPostId(string $postId, PDO $pdo = null): array {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
 
-        $imagesDao = new ImagesDAO($db);
+        $imagesDao = new ImagesDAO($pdo);
         $imagesDtoList = $imagesDao->getImagesByPostId($postId);
 
         $imagesSrcList = [];
@@ -46,11 +48,12 @@ class ImagesRepo {
      * @param string $postId 投稿ID
      * @param boolean $thumbnailFlag サムネイルかどうか
      * @param string $fileExt ファイル拡張子
+     * @param ?PDO $pdo PDOインスタンス
      * @return string 画像ファイル名
      */
-    public static function createImageFile(string $postId, bool $thumbnailFlag, string $fileExt): string {
-        $db = PDOFactory::getPDOInstance();
-        $imagesDao = new ImagesDAO($db);
+    public static function createImageFile(string $postId, bool $thumbnailFlag, string $fileExt, PDO $pdo = null): string {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $imagesDao = new ImagesDAO($pdo);
 
         $imageId = 'image_' . uniqid(mt_rand());
         $filename = $imageId .'.'. convertSpecialCharsToHtmlEntities($fileExt);

--- a/src/models/repo/images.php
+++ b/src/models/repo/images.php
@@ -8,7 +8,7 @@ class ImagesRepo {
      * @return string 画像パス
      */
     public static function getThumbnailSrcByPostId(string $postId): string {
-        $db = PDOFactory::getNewPDOInstance();
+        $db = PDOFactory::getPDOInstance();
 
         $imagesDao = new ImagesDAO($db);
         $imagesDto = $imagesDao->getThumbnailByPostId($postId);
@@ -27,7 +27,7 @@ class ImagesRepo {
      * @return array 画像パスリスト
      */
     public static function getImagesSrcByPostId(string $postId): array {
-        $db = PDOFactory::getNewPDOInstance();
+        $db = PDOFactory::getPDOInstance();
 
         $imagesDao = new ImagesDAO($db);
         $imagesDtoList = $imagesDao->getImagesByPostId($postId);
@@ -38,5 +38,16 @@ class ImagesRepo {
         }
 
         return $imagesSrcList;
+    }
+
+    public static function createImageFile(string $postId, bool $thumbnailFlag, string $fileExt): string {
+        $db = PDOFactory::getPDOInstance();
+        $imagesDao = new ImagesDAO($db);
+
+        $imageId = 'image_' . uniqid(mt_rand());
+        $filename = $imageId .'.'. convertSpecialCharsToHtmlEntities($fileExt);
+        $imagesDao->createImage($imageId, $postId, $thumbnailFlag, $filename);
+
+        return $filename;
     }
 }

--- a/src/models/repo/images.php
+++ b/src/models/repo/images.php
@@ -40,6 +40,14 @@ class ImagesRepo {
         return $imagesSrcList;
     }
 
+    /**
+     * 画像データをテーブルに挿入
+     *
+     * @param string $postId 投稿ID
+     * @param boolean $thumbnailFlag サムネイルかどうか
+     * @param string $fileExt ファイル拡張子
+     * @return string 画像ファイル名
+     */
     public static function createImageFile(string $postId, bool $thumbnailFlag, string $fileExt): string {
         $db = PDOFactory::getPDOInstance();
         $imagesDao = new ImagesDAO($db);

--- a/src/models/repo/posts.php
+++ b/src/models/repo/posts.php
@@ -24,4 +24,10 @@ class PostsRepo {
         $postsDao = new PostsDAO($db);
         return $postsDao->getPosts();
     }
+
+    public static function createPost(string $userId, string $title, string $body): string {
+        $db = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($db);
+        return $postsDao->createPost($userId, $title, $body);
+    }
 }

--- a/src/models/repo/posts.php
+++ b/src/models/repo/posts.php
@@ -5,11 +5,12 @@ class PostsRepo {
      * ユーザーIDを元に投稿数を取得
      *
      * @param string $userId ユーザーID
+     * @param ?PDO $pdo PDOインスタンス
      * @return integer 投稿数
      */
-    public static function getPostsCountByUserId(string $userId): int {
-        $db = PDOFactory::getPDOInstance();
-        $postsDao = new PostsDAO($db);
+    public static function getPostsCountByUserId(string $userId, PDO $pdo = null): int {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($pdo);
         return $postsDao->getPostsCountByUserId($userId);
     }
 
@@ -17,11 +18,12 @@ class PostsRepo {
      * ユーザーIDを元に投稿を取得
      *
      * @param string $userId ユーザーID
+     * @param ?PDO $pdo PDOインスタンス
      * @return array 投稿リスト
      */
-    public static function getPostsByUserId(string $userId): array {
-        $db = PDOFactory::getPDOInstance();
-        $postsDao = new PostsDAO($db);
+    public static function getPostsByUserId(string $userId, PDO $pdo = null): array {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($pdo);
         return $postsDao->getPostsByUserId($userId);
     }
 
@@ -29,22 +31,24 @@ class PostsRepo {
      * 投稿IDを元に投稿情報を取得
      *
      * @param string $postId 投稿ID
-     * @return PostsDTO 投稿情報
+     * @param ?PDO $pdo PDOインスタンス
+     * @return ?PostsDTO 投稿情報
      */
-    public static function getPostById(string $postId): PostsDTO {
-        $db = PDOFactory::getPDOInstance();
-        $postsDao = new PostsDAO($db);
+    public static function getPostById(string $postId, PDO $pdo = null): ?PostsDTO {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($pdo);
         return $postsDao->getPostById($postId);
     }
 
     /**
      * 投稿IDを元に投稿リストを取得
      *
+     * @param ?PDO $pdo PDOインスタンス
      * @return array 投稿リスト
      */
-    public static function getPosts(): array {
-        $db = PDOFactory::getPDOInstance();
-        $postsDao = new PostsDAO($db);
+    public static function getPosts(PDO $pdo = null): array {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($pdo);
         return $postsDao->getPosts();
     }
 
@@ -54,10 +58,11 @@ class PostsRepo {
      * @param string $userId ユーザーID
      * @param string $title タイトル
      * @param string $body 本文
+     * @param ?PDO $pdo PDOインスタンス
      * @return string 投稿ID
      */
-    public static function createPost(string $userId, string $title, string $body): string {
-        $db = PDOFactory::getPDOInstance();
+    public static function createPost(string $userId, string $title, string $body, PDO $pdo = null): string {
+        if (is_null($pdo)) $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         return $postsDao->createPost($userId, $title, $body);
     }

--- a/src/models/repo/posts.php
+++ b/src/models/repo/posts.php
@@ -1,0 +1,15 @@
+<?php
+
+class PostsRepo {
+    public static function getPostsCountByUserId(string $userId): int {
+        $db = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($db);
+        return $postsDao->getPostsCountByUserId($userId);
+    }
+
+    public static function getPostsByUserId(string $userId): array {
+        $db = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($db);
+        return $postsDao->getPostsByUserId($userId);
+    }
+}

--- a/src/models/repo/posts.php
+++ b/src/models/repo/posts.php
@@ -1,30 +1,61 @@
 <?php
 
 class PostsRepo {
+    /**
+     * ユーザーIDを元に投稿数を取得
+     *
+     * @param string $userId ユーザーID
+     * @return integer 投稿数
+     */
     public static function getPostsCountByUserId(string $userId): int {
         $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         return $postsDao->getPostsCountByUserId($userId);
     }
 
+    /**
+     * ユーザーIDを元に投稿を取得
+     *
+     * @param string $userId ユーザーID
+     * @return array 投稿リスト
+     */
     public static function getPostsByUserId(string $userId): array {
         $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         return $postsDao->getPostsByUserId($userId);
     }
 
+    /**
+     * 投稿IDを元に投稿情報を取得
+     *
+     * @param string $postId 投稿ID
+     * @return PostsDTO 投稿情報
+     */
     public static function getPostById(string $postId): PostsDTO {
         $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         return $postsDao->getPostById($postId);
     }
 
-    public static function getPosts() {
+    /**
+     * 投稿IDを元に投稿リストを取得
+     *
+     * @return array 投稿リスト
+     */
+    public static function getPosts(): array {
         $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         return $postsDao->getPosts();
     }
 
+    /**
+     * 投稿を作成
+     *
+     * @param string $userId ユーザーID
+     * @param string $title タイトル
+     * @param string $body 本文
+     * @return string 投稿ID
+     */
     public static function createPost(string $userId, string $title, string $body): string {
         $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);

--- a/src/models/repo/posts.php
+++ b/src/models/repo/posts.php
@@ -12,4 +12,16 @@ class PostsRepo {
         $postsDao = new PostsDAO($db);
         return $postsDao->getPostsByUserId($userId);
     }
+
+    public static function getPostById(string $postId): PostsDTO {
+        $db = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($db);
+        return $postsDao->getPostById($postId);
+    }
+
+    public static function getPosts() {
+        $db = PDOFactory::getPDOInstance();
+        $postsDao = new PostsDAO($db);
+        return $postsDao->getPosts();
+    }
 }

--- a/src/models/repo/tags.php
+++ b/src/models/repo/tags.php
@@ -25,4 +25,13 @@ class TagsRepo {
 
         return $tagsDao->getTagsByPostId($postId);
     }
+
+    public static function addTagsByPostId(array $tags, string $postId): void {
+        $db = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($db);
+
+        foreach($tags as $tag) {
+            $tagsDao->addTagByPostId($tag, $postId);
+        }
+    }
 }

--- a/src/models/repo/tags.php
+++ b/src/models/repo/tags.php
@@ -19,7 +19,7 @@ class TagsRepo {
      * @param int $postId 投稿ID
      * @return array タグの配列
      */
-    public static function getTagsByPostId(int $postId): array {
+    public static function getTagsByPostId(string $postId): array {
         $db = PDOFactory::getPDOInstance();
         $tagsDao = new TagsDAO($db);
 

--- a/src/models/repo/tags.php
+++ b/src/models/repo/tags.php
@@ -4,11 +4,12 @@ class TagsRepo {
     /**
      * タグを取得
      *
+     * @param ?PDO $pdo PDOインスタンス
      * @return array タグの配列
      */
-    public static function getTags(): array {
-        $db = PDOFactory::getPDOInstance();
-        $tagsDao = new TagsDAO($db);
+    public static function getTags(PDO $pdo = null): array {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($pdo);
 
         return $tagsDao->getTags();
     }
@@ -17,11 +18,12 @@ class TagsRepo {
      * タグを取得 (投稿ID指定)
      *
      * @param int $postId 投稿ID
+     * @param ?PDO $pdo PDOインスタンス
      * @return array タグの配列
      */
-    public static function getTagsByPostId(string $postId): array {
-        $db = PDOFactory::getPDOInstance();
-        $tagsDao = new TagsDAO($db);
+    public static function getTagsByPostId(string $postId, PDO $pdo = null): array {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($pdo);
 
         return $tagsDao->getTagsByPostId($postId);
     }
@@ -31,11 +33,12 @@ class TagsRepo {
      *
      * @param array $tags タグの配列
      * @param string $postId 投稿ID
+     * @param ?PDO $pdo PDOインスタンス
      * @return void
      */
-    public static function addTagsByPostId(array $tags, string $postId): void {
-        $db = PDOFactory::getPDOInstance();
-        $tagsDao = new TagsDAO($db);
+    public static function addTagsByPostId(array $tags, string $postId, PDO $pdo = null): void {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($pdo);
 
         foreach($tags as $tag) {
             $tagsDao->addTagByPostId($tag, $postId);

--- a/src/models/repo/tags.php
+++ b/src/models/repo/tags.php
@@ -26,6 +26,13 @@ class TagsRepo {
         return $tagsDao->getTagsByPostId($postId);
     }
 
+    /**
+     * タグを追加 (投稿ID指定)
+     *
+     * @param array $tags タグの配列
+     * @param string $postId 投稿ID
+     * @return void
+     */
     public static function addTagsByPostId(array $tags, string $postId): void {
         $db = PDOFactory::getPDOInstance();
         $tagsDao = new TagsDAO($db);

--- a/src/models/repo/tags.php
+++ b/src/models/repo/tags.php
@@ -1,0 +1,28 @@
+<?php
+
+class TagsRepo {
+    /**
+     * タグを取得
+     *
+     * @return array タグの配列
+     */
+    public static function getTags(): array {
+        $db = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($db);
+
+        return $tagsDao->getTags();
+    }
+
+    /**
+     * タグを取得 (投稿ID指定)
+     *
+     * @param int $postId 投稿ID
+     * @return array タグの配列
+     */
+    public static function getTagsByPostId(int $postId): array {
+        $db = PDOFactory::getPDOInstance();
+        $tagsDao = new TagsDAO($db);
+
+        return $tagsDao->getTagsByPostId($postId);
+    }
+}

--- a/src/models/repo/users.php
+++ b/src/models/repo/users.php
@@ -1,6 +1,12 @@
 <?php
 
 class UsersRepo {
+    /**
+     * メールアドレスからユーザーを取得
+     *
+     * @param string $email メールアドレス
+     * @return UsersDTO ユーザー情報
+     */
     public static function getUserByEmail(string $email): UsersDTO {
         $db = PDOFactory::getPDOInstance();
         $usersDao = new UsersDAO($db);
@@ -8,6 +14,12 @@ class UsersRepo {
         return $usersDao->getUserByEmail($email);
     }
 
+    /**
+     * ユーザーIDからユーザーを取得
+     *
+     * @param string $id ユーザーID
+     * @return UsersDTO ユーザー情報
+     */
     public static function getUserById(string $id): UsersDTO {
         $db = PDOFactory::getPDOInstance();
         $usersDao = new UsersDAO($db);

--- a/src/models/repo/users.php
+++ b/src/models/repo/users.php
@@ -1,0 +1,10 @@
+<?php
+
+class UsersRepo {
+    public static function getUserByEmail(string $email): UsersDTO {
+        $db = PDOFactory::getPDOInstance();
+        $usersDao = new UsersDAO($db);
+
+        return $usersDao->getUserByEmail($email);
+    }
+}

--- a/src/models/repo/users.php
+++ b/src/models/repo/users.php
@@ -7,4 +7,11 @@ class UsersRepo {
 
         return $usersDao->getUserByEmail($email);
     }
+
+    public static function getUserById(string $id): UsersDTO {
+        $db = PDOFactory::getPDOInstance();
+        $usersDao = new UsersDAO($db);
+
+        return $usersDao->getUserById($id);
+    }
 }

--- a/src/models/repo/users.php
+++ b/src/models/repo/users.php
@@ -5,11 +5,12 @@ class UsersRepo {
      * メールアドレスからユーザーを取得
      *
      * @param string $email メールアドレス
-     * @return UsersDTO ユーザー情報
+     * @param ?PDO $pdo PDOインスタンス
+     * @return ?UsersDTO ユーザー情報
      */
-    public static function getUserByEmail(string $email): UsersDTO {
-        $db = PDOFactory::getPDOInstance();
-        $usersDao = new UsersDAO($db);
+    public static function getUserByEmail(string $email, PDO $pdo = null): ?UsersDTO {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $usersDao = new UsersDAO($pdo);
 
         return $usersDao->getUserByEmail($email);
     }
@@ -18,12 +19,35 @@ class UsersRepo {
      * ユーザーIDからユーザーを取得
      *
      * @param string $id ユーザーID
-     * @return UsersDTO ユーザー情報
+     * @param ?PDO $pdo PDOインスタンス
+     * @return ?UsersDTO ユーザー情報
      */
-    public static function getUserById(string $id): UsersDTO {
-        $db = PDOFactory::getPDOInstance();
-        $usersDao = new UsersDAO($db);
+    public static function getUserById(string $id, PDO $pdo = null): ?UsersDTO {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $usersDao = new UsersDAO($pdo);
 
         return $usersDao->getUserById($id);
+    }
+
+    /**
+     * ユーザーを作成
+     *
+     * @param string $username ユーザー名
+     * @param string $email メールアドレス
+     * @param string $password パスワード
+     * @param string $profileImagePath プロフィール画像のパス
+     * @param ?PDO $pdo PDOインスタンス
+     * @return string ユーザーID
+     */
+    public static function createUser(string $username, string $email, string $password, string $profileImagePath = '', PDO $pdo = null): string {
+        if (is_null($pdo)) $pdo = PDOFactory::getPDOInstance();
+        $usersDao = new UsersDAO($pdo);
+
+        $userId = $usersDao->createUser($username, $email, $password, $profileImagePath);
+        if (is_null($userId)) {
+            throw new Exception('ユーザーの作成に失敗しました。サーバーの管理者にお問い合わせください。');
+        }
+
+        return $userId;
     }
 }

--- a/src/public/actions/news.php
+++ b/src/public/actions/news.php
@@ -2,7 +2,6 @@
 
 require_once '../../functions/autoload/actions.php';
 
-PDOFactory::getNewPDOInstance();
 $action = new ActionPage();
 
 $action->post(

--- a/src/public/actions/news.php
+++ b/src/public/actions/news.php
@@ -2,36 +2,28 @@
 
 require_once '../../functions/autoload/actions.php';
 
-
+PDOFactory::getNewPDOInstance();
 $action = new ActionPage();
 
 $action->post(
     function(array $params): ActionResponse {
-        $db = PDOFactory::getNewPDOInstance();
-        $imagesDao = new ImagesDAO($db);
-
         if ($params['title'] === '' || $params['body'] === '') {
             return new ActionResponse('/news/post.php', 'error', 'タイトルと本文は必須です。');
         }
 
         // 一時的にユーザーを固定
-        $usersDao = new UsersDAO($db);
-        $userDto = $usersDao->getUserByEmail('test@test.com');
+        $userDto = UsersRepo::getUserByEmail('test@test.com');
 
         // ニュース投稿データをDBに追加
-        $postsDao = new PostsDAO($db);
-        $newsId = $postsDao->createPost($userDto->id, $params['title'], $params['body']);
+        $postId = PostsRepo::createPost($userDto->id, $params['title'], $params['body']);
 
         // タグをDBに追加
         if (isset($params['tags'])) {
-            $tagsDao = new TagsDAO($db);
-            foreach($params['tags'] as $tag) {
-                $tagsDao->addTagByPostId($tag, $newsId);
-            }
+            TagsRepo::addTagsByPostId($params['tags'], $postId);
         }
 
         // 画像フォルダ作成
-        $imageDir = __DIR__ .'/../img/news/'. $newsId;
+        $imageDir = __DIR__ .'/../img/news/'. $postId;
         mkdir($imageDir, 0777, true);
 
         // 画像ファイル移動
@@ -44,14 +36,11 @@ $action->post(
                 continue;
             }
 
-            $imageId = 'image_' . uniqid(mt_rand());
-            $filename = $imageId .'.'. convertSpecialCharsToHtmlEntities($ext);
-            $imagesDao->createImage($imageId, $newsId, $key === 'thumbnail', $filename);
-
+            $filename = ImagesRepo::createImageFile($postId, $key === 'thumbnail', $ext);
             move_uploaded_file($value['tmp_name'], $imageDir .'/'. $filename);
         }
 
-        return new ActionResponse('/', 'success', 'ニュースを投稿しました。ID: '. $newsId);
+        return new ActionResponse('/', 'success', 'ニュースを投稿しました。ID: '. $postId);
     },
     ['title' => 'string', 'body' => 'string']
 );
@@ -62,7 +51,7 @@ $action->put(
             return new ActionResponse('/news/edit.php?id='. $params['id'], 'error', 'タイトルと本文は必須です。');
         }
 
-        $db = PDOFactory::getNewPDOInstance();
+        $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
         $postsDao->putPostById($params['id'], $params['title'], $params['body']);
 
@@ -73,12 +62,12 @@ $action->put(
 
 $action->delete(
     function(array $params): ActionResponse {
-        $newsId = $_GET['id'];
-        $db = PDOFactory::getNewPDOInstance();
+        $postId = $params['id'];
+        $db = PDOFactory::getPDOInstance();
         $postsDao = new PostsDAO($db);
-        $postsDao->deletePostById($newsId);
+        $postsDao->deletePostById($postId);
 
-        return new ActionResponse('/', 'success', 'ニュースを削除しました。 ID: '. $newsId);
+        return new ActionResponse('/', 'success', 'ニュースを削除しました。 ID: '. $postId);
     },
     ['id' => 'string']
 );

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -3,4 +3,6 @@
 require_once '../functions/autoload/views.php';
 require_once '../components/pages/home.php';
 
+PDOFactory::getNewPDOInstance();
+
 Home::render();

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -3,6 +3,4 @@
 require_once '../functions/autoload/views.php';
 require_once '../components/pages/home.php';
 
-PDOFactory::getNewPDOInstance();
-
 Home::render();

--- a/src/public/news/edit.php
+++ b/src/public/news/edit.php
@@ -3,6 +3,4 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-PDOFactory::getNewPDOInstance();
-
 News::render(NewsMode::EDIT);

--- a/src/public/news/edit.php
+++ b/src/public/news/edit.php
@@ -3,4 +3,6 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-News::render(MODE_EDIT);
+PDOFactory::getNewPDOInstance();
+
+News::render(NewsMode::EDIT);

--- a/src/public/news/index.php
+++ b/src/public/news/index.php
@@ -3,6 +3,4 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-PDOFactory::getNewPDOInstance();
-
 News::render(NewsMode::VIEW);

--- a/src/public/news/index.php
+++ b/src/public/news/index.php
@@ -3,4 +3,6 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-News::render(MODE_VIEW);
+PDOFactory::getNewPDOInstance();
+
+News::render(NewsMode::VIEW);

--- a/src/public/news/post.php
+++ b/src/public/news/post.php
@@ -3,6 +3,4 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-PDOFactory::getNewPDOInstance();
-
 News::render(NewsMode::CREATE);

--- a/src/public/news/post.php
+++ b/src/public/news/post.php
@@ -3,4 +3,6 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/news.php';
 
-News::render(MODE_CREATE);
+PDOFactory::getNewPDOInstance();
+
+News::render(NewsMode::CREATE);

--- a/src/public/user/index.php
+++ b/src/public/user/index.php
@@ -3,4 +3,6 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/user.php';
 
+PDOFactory::getNewPDOInstance();
+
 User::render();

--- a/src/public/user/index.php
+++ b/src/public/user/index.php
@@ -3,6 +3,4 @@
 require_once '../../functions/autoload/views.php';
 require_once '../../components/pages/user.php';
 
-PDOFactory::getNewPDOInstance();
-
 User::render();


### PR DESCRIPTION
## 変更概要
- 全体のリファクタリング
  - 各メソッドの引数・戻り値の調整
  - 処理の最適化
  - 変数名の統一・enumに置き換え
  - DB操作はRepoで行うように修正
  - DAOのSQLを整形
  - `getPDOInstance()`に置き換え。`getNewPDOInstance()`はページごとに行うように修正
- MarkDownで投稿できるように実装